### PR TITLE
Also handle info messages from previous tasks.

### DIFF
--- a/run.exs
+++ b/run.exs
@@ -240,10 +240,21 @@ defmodule PhoenixDemo.SampleLive do
     {:noreply, socket}
   end
 
-  def handle_info({ref, result}, %{assigns: %{task_ref: ref}} = socket) do
+  def handle_info({ref, result}, %{assigns: %{task_ref: task_ref}} = socket) do
     Process.demonitor(ref, [:flush])
-    %{predictions: [%{label: label}]} = result
-    {:noreply, assign(socket, label: label, running: false)}
+
+    socket =
+      case ref do
+        ^task_ref ->
+          %{predictions: [%{label: label}]} = result
+          assign(socket, label: label)
+
+        # ignore obsolete task results
+        _ ->
+          socket
+      end
+
+    {:noreply, assign(socket, running: false)}
   end
 end
 


### PR DESCRIPTION
This is a great example of how to do async stuff and handle it in the `handle_info` callback. The only issue I saw (with a longer running task), is that when two or more tasks are spawned concurrently, the older tasks won't be matched in the `handle_info` callback (due to the strict match expression). Just a small thing, but might be more complete as a reference like this....

If the `task_ref` is from a previous task, just demonitor it and ignore the result. If a second task is spawned, the `task_ref` of the first task won't be matched in `handle_info` and the LV will exit.